### PR TITLE
zulip followups

### DIFF
--- a/dag/assets/transform/zulip.py
+++ b/dag/assets/transform/zulip.py
@@ -14,6 +14,7 @@ def transform_zulip_members(extract_zulip_members):
     members = extract_zulip_members.mutate(
         date_joined=ibis._.date_joined.cast("timestamp")
     )
+    members = members.filter(ibis._.is_bot == False)
     members = members.order_by(ibis._.date_joined.desc())
     members = members.relocate("full_name", "date_joined", "timezone")
     members = members.mutate(total_members=ibis._.count().over(rows=(0, None)))
@@ -29,6 +30,10 @@ def transform_zulip_messages(extract_zulip_messages):
         timestamp=ibis._.timestamp.cast("timestamp"),
         last_edit_timestamp=ibis._.last_edit_timestamp.cast("timestamp"),
     )
+    # TODO: either automatically filter out bot messages or do something better here
+    messages = messages.filter(
+        ibis._.stream_id != 405931
+    )  # filter out the github-issues stream for now
     messages = messages.order_by(
         ibis._.timestamp.desc(),
     )


### PR DESCRIPTION
closes #42

filters out bots (currently only 1) from the Zulip members data and the `github-issues` stream from the messages data

as a follow up to this, should probably do something more fancy (i.e. separately record bot messages if those expand, get rid of hard-coding the stream id)
